### PR TITLE
Add programs needed for pip's VCS support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN zypper addrepo -f \
 RUN zypper --no-gpg-checks --non-interactive dist-upgrade && \
   zypper --non-interactive install -t pattern devel_basis && \
   zypper --non-interactive install \
+  bzr \
   cppcheck \
   curl \
   espeak \
@@ -25,6 +26,7 @@ RUN zypper --no-gpg-checks --non-interactive dist-upgrade && \
   git \
   go \
   gsl \
+  mercurial \
   hlint \
   indent \
   java \
@@ -53,6 +55,7 @@ RUN zypper --no-gpg-checks --non-interactive dist-upgrade && \
   ruby \
   ruby-devel \
   ShellCheck \
+  subversion \
   sudo \
   suitesparse-devel \
   tar \


### PR DESCRIPTION
Add mecurial, bzr and subversion programs to enable
using pip's VCS support to fetch development versions.
https://pip.pypa.io/en/latest/reference/pip_install/#vcs-support
