### PR TITLE
Install coala-bears master requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ WORKDIR /
 
 RUN git clone https://github.com/coala-analyzer/coala-bears.git
 WORKDIR /coala-bears
+RUN pip3 install -r requirements.txt -r test-requirements.txt
 RUN git checkout release/0.8
 RUN pip3 install -r requirements.txt
 RUN pip3 install -r test-requirements.txt


### PR DESCRIPTION
Pre-install extra dependencies of coala-bears master,
so the image can be used to easily test unreleased coala
bug-fixes and features on repositories where the released
coala doesnt work optimally.

Fixes https://github.com/coala/docker-coala-base/issues/17
