### PR TITLE
Dockerfile: Enable and fix Julia requirements install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN zypper --no-gpg-checks --non-interactive dist-upgrade && \
   libcurl-devel \
   libncurses5 \
   libopenssl-devel \
+  libpcre2-8-0 \
   libxml2-tools \
   lua \
   lua-devel \
@@ -126,7 +127,7 @@ RUN source /etc/profile.d/go.sh \
 # ENV PATH=$PATH:/home/opam/infer-linux64-v0.9.0/infer/bin
 
 # Julia setup
-# RUN ["julia", "-e", "\\"Pkg.add(\\\\"Lint\\\\")\\""]
+RUN julia -e 'Pkg.add("Lint")'
 
 # Lua commands
 RUN luarocks install luacheck


### PR DESCRIPTION
This is a little hacky, but it works. We just have to remember to remove pcre2-8-0 when julia updates.

Julia requirements were disabled before. This patch enables
the "Lint" julia package. It also install libpcre2-8-0
to fix julia which seems to be dynamically linked against this
specific version. This patch should enable docker building.

Fixes #18
Fixes #35