### PR TITLE
Reduce openSUSE packages installed and upgraded

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,7 @@ RUN zypper addrepo http://download.opensuse.org/repositories/home:illuusio/openS
   # Add repo for rubygem-bundler
   zypper addrepo http://download.opensuse.org/repositories/home:AtastaChloeD:ChiliProject/openSUSE_Factory/home:AtastaChloeD:ChiliProject.repo && \
   # Package dependencies
-  zypper --no-gpg-checks --non-interactive dist-upgrade && \
-  zypper --non-interactive install -t pattern devel_basis && \
-  zypper --non-interactive install \
+  zypper --no-gpg-checks --non-interactive install \
     bzr \
     cppcheck \
     curl \
@@ -50,6 +48,7 @@ RUN zypper addrepo http://download.opensuse.org/repositories/home:illuusio/openS
     mono \
     nodejs \
     npm \
+    patch \
     perl \
     perl-Perl-Critic \
     php \


### PR DESCRIPTION
Do not perform dist-upgrade or install pattern devel_basis.
They are separate commands each needing to load the package
database and add an extra 200Mb to the installed image.

Dist-upgrade updates 44 packages, most of which are not used
(e.g. krb5-mini) or the existing version is ok (e.g. bash).
The only components needing upgrading are libgcc_s1 and libstdc++6.

Of the devel_basis, only `patch` is needed for ruby gem `pg_query`,
which is used by `sqlint` for `SQLintBear`.