### PR TITLE
Dockerfile: Remove and Reduce unused packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN zypper addrepo http://download.opensuse.org/repositories/home:illuusio/openS
     bzr \
     cppcheck \
     curl \
-    espeak \
     expect \
     flawfinder \
     gcc-c++ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,7 @@ RUN zypper addrepo http://download.opensuse.org/repositories/home:illuusio/openS
     mercurial \
     hlint \
     indent \
-    java \
-    java-1_8_0-openjdk-devel \
+    java-1_8_0-openjdk \
     julia \
     libcholmod-3_0_6 \
     libclang3_8 \
@@ -62,7 +61,6 @@ RUN zypper addrepo http://download.opensuse.org/repositories/home:illuusio/openS
     python3-setuptools \
     R-base \
     ruby \
-    ruby-common \
     ruby-devel \
     ruby2.2-rubygem-bundler \
     ShellCheck \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ RUN zypper addrepo http://download.opensuse.org/repositories/home:illuusio/openS
     lua-devel \
     luarocks \
     m4 \
-    mono \
     nodejs \
     npm \
     patch \


### PR DESCRIPTION
espeak is removed because the associated linter is removed, see https://github.com/coala/coala/issues/1939.

Mono is removed because CSharpLintBear is broken, see https://github.com/coala/docker-coala-base/issues/65

OpenJDK development packages is replaced with a smaller JRE package because PMD and Checkstyle doesn't require JDK.

ruby-common is removed because ruby and ruby-devel is more than enough.

With all of these changes, we've reduced around ~113 MB