### PR TITLE
Re-enable VHDL Bakalint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
       rm bears/c_languages/CSharpLintBear.py tests/c_languages/CSharpLintBearTest.py;
       rm bears/java/InferBear.py tests/java/InferBearTest.py;
       rm -r bears/verilog tests/verilog/;
-      rm -r bears/vhdl tests/vhdl/;
       python3 -m pytest --cov --cov-fail-under=100
     "
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM opensuse:tumbleweed
 MAINTAINER Fabian Neuschmidt fabian@neuschmidt.de
 
 # Set the locale
-ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en PATH=$PATH:/root/pmd-bin-5.4.1/bin:/root/dart-sdk/bin:/coala-bears/node_modules/.bin
+ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en PATH=$PATH:/root/pmd-bin-5.4.1/bin:/root/dart-sdk/bin:/coala-bears/node_modules/.bin:/root/bakalint-0.4.0
 
 # Add packaged flawfinder
 RUN zypper addrepo http://download.opensuse.org/repositories/home:illuusio/openSUSE_Tumbleweed/home:illuusio.repo && \
@@ -165,7 +165,5 @@ RUN curl -fsSL https://tailor.sh/install.sh | sed 's/read -r CONTINUE < \/dev\/t
   /bin/bash install.sh
 
 # # VHDL Bakalint Installation
-# ADD http://downloads.sourceforge.net/project/fpgalibre/bakalint/0.4.0/bakalint-0.4.0.tar.gz?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Ffpgalibre%2Ffiles%2Fbakalint%2F0.4.0%2F&ts=1461844926&use_mirror=netcologne /root/bl.tar.gz
-# RUN tar xf /root/bl.tar.gz -C /root/
-# ENV PATH=$PATH:/root/bakalint-0.4.0
-
+RUN curl -L 'http://downloads.sourceforge.net/project/fpgalibre/bakalint/0.4.0/bakalint-0.4.0.tar.gz' > /root/bl.tar.gz && \
+  tar xf /root/bl.tar.gz -C /root/


### PR DESCRIPTION
curl can be used to download the linter from sourceforge without any issues

Closes https://github.com/coala/docker-coala-base/issues/71