### PR TITLE
Dockerfile: Run script if there's no command being passed

### DIFF
--- a/.ci/hello-world.py
+++ b/.ci/hello-world.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+# This is a subject to test the Docker Image
+
+import sys
+
+
+def main():
+    print('Hello world!')
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ script:
       rm -r bears/verilog tests/verilog/;
       python3 -m pytest --cov --cov-fail-under=100
     "
-
+  - /bin/sh -c "! docker run coala-docker"
+  - docker run --volume=$(pwd)/.ci:/work --workdir=/work coala-docker
+  - ls -la ./.ci/.coafile
 notifications:
   email: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -171,3 +171,7 @@ RUN curl -fsSL https://tailor.sh/install.sh | sed 's/read -r CONTINUE < \/dev\/t
 # # VHDL Bakalint Installation
 RUN curl -L 'http://downloads.sourceforge.net/project/fpgalibre/bakalint/0.4.0/bakalint-0.4.0.tar.gz' > /root/bl.tar.gz && \
   tar xf /root/bl.tar.gz -C /root/
+
+# Entrypoint script
+ADD docker-coala.sh /usr/local/bin/
+CMD ["/usr/local/bin/docker-coala.sh"]

--- a/docker-coala.sh
+++ b/docker-coala.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# coala Docker Image entrypoint script
+# This script is run if there's no command being passed
+
+PREFIX="\033[1;34m>> \033[0m"
+
+function msg {
+    echo -e "$PREFIX$@"
+}
+
+# Declare this is a dumb terminal
+# because by default docker doesn't create a pseudo-tty
+export TERM="dumb"
+
+# Check if the working directory is changed from the default
+if [[ "$(pwd)" == "/" ]]; then
+    msg "It looks like you forgot to define a working directory\n"
+    msg "To properly use this Docker Image,"
+    msg "You have to bind your project to this container and" \
+        "set the working directory to the container-side bind, like this:"
+    msg "docker run coala/base --volume=\$(pwd):/work --workdir=/work [command]"
+
+    exit 1
+fi
+
+# Check if .gitignore exists
+# See https://github.com/coala/coala-quickstart/issues/49
+if [[ ! -f .gitignore ]]; then
+    msg "It looks like there's no .gitignore file," \
+        "Creating a blank one ..."
+
+    touch .gitignore
+fi
+
+# Check if .coafile exists
+if [[ ! -f .coafile ]]; then
+    msg ".coafile doesn't exist," \
+        "Running coala-quickstart to create one ..."
+
+    coala-quickstart --non-interactive
+fi
+
+# Run coala non-interactively
+msg "Running coala non-interactively ..."
+coala --non-interactive


### PR DESCRIPTION
Dockerfile now has a script to run if there's no command being
passed. The script will check if there's a project by checking the
working directory, create a .coafile with coala-quickstart if it
doesn't exist, and run coala non-interactively by default.

Closes https://github.com/coala/docker-coala-base/issues/76