### PR TITLE
[DNM] Add zypper package ghc-mod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ script:
       rm bears/Constants.py;  # There are no tests covering this module
       rm bears/c_languages/CSharpLintBear.py tests/c_languages/CSharpLintBearTest.py;
       rm bears/java/InferBear.py tests/java/InferBearTest.py;
-      rm bears/haskell/GhcModBear.py tests/haskell/GhcModBearTest.py;
       rm -r bears/verilog tests/verilog/;
       python3 -m pytest --cov --cov-fail-under=100;
       cd /tmp;

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ RUN zypper addrepo http://download.opensuse.org/repositories/home:illuusio/openS
     flawfinder \
     gcc-c++ \
     gcc-fortran \
+    ghc \
+    ghc-cabal-helper \
+    ghc-mod \
     git \
     go \
     gsl \


### PR DESCRIPTION
ghc and ghc-cabal-helper are dependencies that are not
managed via zypper packaging.

Fixes https://github.com/coala/docker-coala-base/issues/87