### PR TITLE
Remove /usr/share/{doc|info|man}

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,11 @@ RUN zypper addrepo http://download.opensuse.org/repositories/home:illuusio/openS
     xorg-x11-fonts \
     xorg-x11-fonts-core \
     && \
+  rm -rf \
+    /usr/share/doc/ \
+    /usr/share/man/ \
+    /usr/share/info/ \
+    && \
   # Clear zypper cache
   zypper clean -a
 


### PR DESCRIPTION
These directories contain files not needed by a Docker image,
which add about 100Mb to the image size.