### PR TITLE
Use headless java

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN zypper addrepo http://download.opensuse.org/repositories/home:illuusio/openS
     mercurial \
     hlint \
     indent \
-    java-1_8_0-openjdk \
+    java-1_8_0-openjdk-headless \
     julia \
     libcholmod-3_0_6 \
     libclang3_8 \


### PR DESCRIPTION
Headless java doesnt include audio and video support,
which is not needed by the coala docker image.