### PR TITLE
.travis.yml: Use generic image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+language: generic
 
 services:
   - docker


### PR DESCRIPTION
If not specified, the default image is ruby,
which isnt needed for this repository, and takes
a minute to set up the ruby engine.