### PR TITLE
.travis.yml: Fix coala tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ install:
 script:
   - >
     docker run -t -i coala-docker /bin/sh -c "
-      cd /coala; python3 -m pytest --cov --cov-fail-under=100;
+      set -e -x
+      export OS_NAME=posix;
+      cd /coala; python3 -m pytest;
       cd /coala-bears;
       rm bears/Constants.py;  # There are no tests covering this module
       rm bears/c_languages/CSharpLintBear.py tests/c_languages/CSharpLintBearTest.py;


### PR DESCRIPTION
Remove --cov from command line, as coverage was recently enabled
in the coala setup.cfg.

Also set OS_NAME=posix.

And add set -x -e to block builds with failures.

Fixes https://github.com/coala/docker-coala-base/issues/96