### PR TITLE
Dockerfile: Add build argument `branch`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,12 @@ language: generic
 services:
   - docker
 
+# Set environment variable COALA_BRANCH=<branch> to override
+# the default.
+
 install:
-  - docker build -f Dockerfile -t coala-docker .
+  - export COALA_BRANCH=$(python guess_branch.py "$TRAVIS_BRANCH") && echo $COALA_BRANCH
+  - docker build -f Dockerfile --build-arg branch=$COALA_BRANCH -t coala-docker .
   - docker images
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM opensuse:tumbleweed
 MAINTAINER Fabian Neuschmidt fabian@neuschmidt.de
 
+ARG branch=master
+
 # Set the locale
 ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en PATH=$PATH:/root/pmd-bin-5.4.1/bin:/root/dart-sdk/bin:/coala-bears/node_modules/.bin:/root/bakalint-0.4.0
 
@@ -159,8 +161,8 @@ RUN zypper addrepo http://download.opensuse.org/repositories/home:illuusio/openS
 
 # Coala setup and python deps
 RUN cd / && \
-  git clone --depth 1 https://github.com/coala/coala.git && \
-  git clone --depth 1 https://github.com/coala/coala-bears.git && \
+  git clone --depth 1 --branch=$branch https://github.com/coala/coala.git && \
+  git clone --depth 1 --branch=$branch https://github.com/coala/coala-bears.git && \
   git clone --depth 1 https://github.com/coala/coala-quickstart.git && \
   time pip3 install --no-cache-dir \
     -e /coala \

--- a/guess_branch.py
+++ b/guess_branch.py
@@ -1,0 +1,31 @@
+from __future__ import print_function
+
+import re
+import os
+import sys
+
+
+def guess_coala_branch_name(docker_branch_name):
+    m = re.search('r(?:el)?(?:ease)?[^0-9]?([0-9]+\.[0-9]+(\.[0-9]+)*)',
+                  docker_branch_name)
+    if m:
+        release_number = m.group(1)
+        float(release_number)
+        return 'release/' + release_number
+
+    return 'master'
+
+
+def main():
+    args = sys.argv[1:]
+    assert args
+    assert len(args) == 1
+    docker_branch_name = args[0]
+    if 'COALA_BRANCH' in os.environ:
+        print(os.environ['COALA_BRANCH'])
+    else:
+        print(guess_coala_branch_name(docker_branch_name))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The docker build argument `branch` can be used to build branches
of coala other than master without modifying the Dockerfile.

COALA_BRANCH can be set in Travis CI environment settings to
choose the branch, otherwise a branch name like release-0.10
will automatically choose branch 'release/0.10'.