### PR TITLE
Remove python3-gobject

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,10 +68,9 @@ RUN zypper addrepo http://download.opensuse.org/repositories/home:illuusio/openS
     # Used by bzr, mecurial, hgext, and flawfinder
     python \
     python3 \
+    # Needed for proselint
     python3-dbm \
-    python3-gobject \
     python3-pip \
-    python3-setuptools \
     R-base \
     ruby \
     ruby-devel \
@@ -90,8 +89,6 @@ RUN zypper addrepo http://download.opensuse.org/repositories/home:illuusio/openS
     fdupes \
     fontconfig \
     fonts-config \
-    gio-branding-openSUSE \
-    glib2-tools \
     kbd \
     iproute2 \
     kmod \


### PR DESCRIPTION
python3-gobject was added in 90ed5fd9, and presumably
was necessary for dbus support.  Removing it saves 9Mb.

Also remove two forced removals of unneeded dependencies
of python3-gobject:
- gio-branding-openSUSE
- glib2-tools

Add explanation for python3-gdbm.
Remove explicit python3-setuptools, also added in 90ed5fd9,
which is one of many implicit dependencies of python3-pip.

Related to https://github.com/coala/docker-coala-base/issues/55
Related to https://github.com/coala/coala/issues/2949