### PR TITLE
Add science repo for fixed Julia

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,10 @@ RUN zypper addrepo http://download.opensuse.org/repositories/home:illuusio/openS
   # Add repo for rubygem-bundler
   zypper addrepo http://download.opensuse.org/repositories/home:AtastaChloeD:ChiliProject/openSUSE_Factory/home:AtastaChloeD:ChiliProject.repo && \
   # Package dependencies
-  time zypper --no-gpg-checks --non-interactive install \
+  time zypper --no-gpg-checks --non-interactive \
+      # science contains latest Julia
+      --plus-repo http://download.opensuse.org/repositories/science/openSUSE_Tumbleweed/ \
+      install \
     bzr \
     cppcheck \
     curl \


### PR DESCRIPTION
Package `julia` available from the main repos, depends on libgit2-24,
which has been removed in favour of libgit2-25, creating
an unresolved dependency.

This has been fixed in the `science` repo, and hasnt been propagated
to the main repos yet.

Fixes https://github.com/coala/docker-coala-base/issues/142