### PR TITLE
Verify rpm.install.excludedocs = yes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
       set -e -x;
       /work/pytest.sh;
       /work/vcs.sh;
+      /work/opensuse.sh;
     "
   # Verify MarkdownBear works outside of coala-bears directory.
   # See https://github.com/coala/coala-bears/issues/1235

--- a/tests/opensuse.sh
+++ b/tests/opensuse.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e -x
+
+# Ensure docks are being excluded, otherwise image size is much larger
+
+grep -q 'rpm.install.excludedocs = yes' /etc/zypp/zypp.conf


### PR DESCRIPTION
Sanity check.
If this flag changes, the size of the image radically increases.