### PR TITLE
Dockerfile: Undo removal of lksctp-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,6 @@ RUN zypper addrepo http://download.opensuse.org/repositories/home:illuusio/openS
     libXrender1 \
     libxslt-tools \
     libXss1 libXt6 libXxf86vm1 \
-    lksctp-tools \
     logrotate \
     ncurses-utils \
     openssh \


### PR DESCRIPTION
lksctp-tools is no longer an indirect installs.
Forceful deletion of it is no longer needed.

Fixes https://github.com/coala/docker-coala-base/issues/153