### PR TITLE
MarkdownBear: Set NODE_PATH for remark-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
       cd /tmp;
       svn co https://github.com/githubtraining/hellogitworld.git;
       bzr branch lp:govcstestbzrrepo;
-      hg clone http://www.selenic.com/repo/hello;
+      hg clone https://bitbucket.org/fracai/empty-hg;
     "
   - /bin/sh -c "! docker run coala-docker"
   - docker run --volume=$(pwd)/.ci/sample:/work --workdir=/work coala-docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,14 @@ script:
       bzr branch lp:govcstestbzrrepo;
       hg clone https://bitbucket.org/fracai/empty-hg;
     "
+  # Verify MarkdownBear works outside of coala-bears directory.
+  # See https://github.com/coala/coala-bears/issues/1235
+  - >
+    docker run -t -i coala-docker /bin/sh -c "
+      cd /tmp;
+      echo foo > foo.md;
+      coala --non-interactive --no-config --bears MarkdownBear --files foo.md;
+    "
   - /bin/sh -c "! docker run coala-docker"
   - docker run --volume=$(pwd)/.ci/sample:/work --workdir=/work coala-docker
   - ls -la ./.ci/sample/.coafile

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ MAINTAINER Fabian Neuschmidt fabian@neuschmidt.de
 ARG branch=master
 
 # Set the locale
-ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en PATH=$PATH:/root/pmd-bin-5.4.1/bin:/root/dart-sdk/bin:/coala-bears/node_modules/.bin:/root/bakalint-0.4.0:/root/elm-format-0.18
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    PATH=$PATH:/root/pmd-bin-5.4.1/bin:/root/dart-sdk/bin:/coala-bears/node_modules/.bin:/root/bakalint-0.4.0:/root/elm-format-0.18 \
+    NODE_PATH=/coala-bears/node_modules
 
 # Create symlink for cache
 RUN mkdir -p /root/.local/share/coala && \


### PR DESCRIPTION
remark-cli needs to find its plugins.  When invoked in `/coala-bears`
directory, Node automatically looks in `node_modules`.  However if
the docker image is used normally the working directory will not
be `/coala-bears`.  Setting NODE_PATH ensures that the plugins can
be found.

Related to https://github.com/coala/coala-bears/issues/1235