### PR TITLE
Use official rubygem-bundler package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,6 @@ RUN mkdir -p /root/.local/share/coala && \
 RUN zypper addrepo http://download.opensuse.org/repositories/home:illuusio/openSUSE_Tumbleweed/home:illuusio.repo && \
   # Use Leap for nodejs
   zypper addrepo http://download.opensuse.org/repositories/devel:languages:nodejs/openSUSE_Leap_42.2/devel:languages:nodejs.repo && \
-  # Add repo for rubygem-bundler
-  zypper addrepo http://download.opensuse.org/repositories/home:AtastaChloeD:ChiliProject/openSUSE_Factory/home:AtastaChloeD:ChiliProject.repo && \
   # Remove unnecessary repos to avoid refreshes
   zypper removerepo 'NON-OSS' && \
   # Package dependencies


### PR DESCRIPTION
The repository previously used for rubygem-bundler has been deleted.

Fixes https://github.com/coala/docker-coala-base/issues/161