### PR TITLE
Revert "Add dependencies licensecheck and elm-format"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG branch=master
 # Set the locale
 ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
-    PATH=$PATH:/root/pmd-bin-5.4.1/bin:/root/dart-sdk/bin:/coala-bears/node_modules/.bin:/root/bakalint-0.4.0:/root/elm-format-0.18 \
+    PATH=$PATH:/root/pmd-bin-5.4.1/bin:/root/dart-sdk/bin:/coala-bears/node_modules/.bin:/root/bakalint-0.4.0 \
     NODE_PATH=/coala-bears/node_modules
 
 # Create symlink for cache
@@ -50,8 +50,6 @@ RUN zypper addrepo http://download.opensuse.org/repositories/home:illuusio/openS
     libpcre2-8-0 \
     # libxml2-tools provides xmllint
     libxml2-tools \
-    # needed for licensecheck
-    devscripts \
     # linux-glibc-devel needed for Ruby native extensions
     linux-glibc-devel \
     lua \
@@ -225,11 +223,6 @@ RUN time pear install PHP_CodeSniffer && \
 # Dart Lint setup
 RUN curl -fsSL https://storage.googleapis.com/dart-archive/channels/stable/release/1.14.2/sdk/dartsdk-linux-x64-release.zip -o /tmp/dart-sdk.zip && \
   unzip -n /tmp/dart-sdk.zip -d ~/ && \
-  find /tmp -mindepth 1 -prune -exec rm -rf '{}' '+'
-
-RUN curl -fsSL https://github.com/avh4/elm-format/releases/download/0.5.2-alpha/elm-format-0.17-0.5.2-alpha-linux-x64.tgz -o /tmp/elm-format.tgz && \
-  mkdir ~/elm-format-0.18 && \
-  tar -xvzf /tmp/elm-format.tgz -C ~/elm-format-0.18 && \
   find /tmp -mindepth 1 -prune -exec rm -rf '{}' '+'
 
 # GO setup


### PR DESCRIPTION
This reverts commit 38d578c2d6cf7b0981aa8b6e10e423696c93eac7,
which added dependencies for two bears added to 0.11,
that are not needed for 0.10.