### PR TITLE
Remove uninstallation of three packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,11 +121,8 @@ RUN zypper addrepo http://download.opensuse.org/repositories/home:illuusio/openS
     perl-X11-Protocol \
     postfix \
     php7-zlib \
-    python-cssselect \
     python-curses \
     python-javapackages \
-    python-lxml \
-    python-Pygments \
     python-pyxb \
     python-rpm-macros \
     python-xml \


### PR DESCRIPTION
The following packages are no longer automatically installed:

- python-cssselect
- python-lxml
- python-Pygments

They do not need to be forcibly uninstalled.

Fixes https://github.com/coala/docker-coala-base/issues/165