### PR TITLE
Release 0.9: build fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,6 @@ RUN zypper addrepo -f \
 # Use Leap for nodejs
 RUN zypper addrepo http://download.opensuse.org/repositories/devel:languages:nodejs/openSUSE_Leap_42.2/devel:languages:nodejs.repo
 
-# Add repo for rubygem-bundler
-RUN zypper addrepo http://download.opensuse.org/repositories/home:AtastaChloeD:ChiliProject/openSUSE_Factory/home:AtastaChloeD:ChiliProject.repo
-
 # Package dependencies
 RUN zypper --no-gpg-checks --non-interactive dist-upgrade && \
   zypper --non-interactive install -t pattern devel_basis && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,7 @@ RUN source /etc/profile.d/go.sh \
   && go get -u github.com/golang/lint/golint \
   && go get -u golang.org/x/tools/cmd/goimports \
   && go get -u sourcegraph.com/sqs/goreturns \
-  && go get -u golang.org/x/tools/cmd/gotype \
+  && go get -u github.com/jayvdb/gotype \
   && go get -u github.com/kisielk/errcheck
 
 # # Infer setup using opam


### PR DESCRIPTION
The 0.9 docker image build was broken by changes in the Go repository, and openSUSE repositories.