### PR TITLE
Dockerfile: Show value of argument $branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM opensuse:tumbleweed
 MAINTAINER Fabian Neuschmidt fabian@neuschmidt.de
 
 ARG branch=master
+RUN echo branch=$branch
 
 # Set the locale
 ENV LANG=en_US.UTF-8 \


### PR DESCRIPTION
Docker ARG values are not shown.
Instead it shows the ARG line as-is, which confusingly
suggests that the value of `branch` is `master` when
it is not.

Related to https://github.com/coala/docker-coala-base/issues/171