### PR TITLE
Add docker build hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,13 @@ services:
 
 # Set environment variable COALA_BRANCH=<branch> to override
 # the default.
+env:
+  global:
+    - SOURCE_BRANCH=$TRAVIS_BRANCH
+    - IMAGE_NAME=coala-docker
 
 install:
-  - export COALA_BRANCH=$(python guess_branch.py "$TRAVIS_BRANCH") && echo $COALA_BRANCH
-  - docker build -f Dockerfile --build-arg branch=$COALA_BRANCH -t coala-docker .
+  - hooks/build
 
 script:
   - docker images

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+COALA_BRANCH=$(python guess_branch.py "$SOURCE_BRANCH")
+
+echo Building coala branch $COALA_BRANCH for docker branch $SOURCE_BRANCH
+
+docker build -f Dockerfile --build-arg=branch=$COALA_BRANCH -t $IMAGE_NAME .


### PR DESCRIPTION
`hooks/build` is used, when present, to invoke docker build.
It adds the argument `branch` with the source branch name.

Fixes https://github.com/coala/docker-coala-base/issues/171