### PR TITLE
Dockerfile: Remove fork of gotype

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -240,7 +240,7 @@ RUN source /etc/profile.d/go.sh && time go get -u \
   github.com/golang/lint/golint \
   golang.org/x/tools/cmd/goimports \
   sourcegraph.com/sqs/goreturns \
-  github.com/jayvdb/gotype \
+  golang.org/x/tools/cmd/gotype \
   github.com/kisielk/errcheck && \
   find /tmp -mindepth 1 -prune -exec rm -rf '{}' '+'
 


### PR DESCRIPTION
Remove fork of gotype, as golang.org/x/tools/cmd/gotype
package is back again and is go-gettable