### PR TITLE
Dockerfile: Specify exact zypper package names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,11 +65,11 @@ RUN \
     luarocks \
     m4 \
     nodejs6 \
-    npm \
+    npm6 \
     # patch is used by Ruby gem pg_query
     patch \
     perl-Perl-Critic \
-    php \
+    php7 \
     php7-pear \
     # Needed for PHPMD
     php7-dom \


### PR DESCRIPTION
Packages npm and php result in the message:

'npm' not found in package names. Trying capabilities.
'php' not found in package names. Trying capabilities.

They resolve using capabilities, but that can be avoided
by using exact package names npm6 and php7.

Closes https://github.com/coala/docker-coala-base/issues/191