### PR TITLE
Ensure tailor installation succeeds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -305,7 +305,11 @@ RUN mkdir -p ~/.RLibrary && \
   find /tmp -mindepth 1 -prune -exec rm -rf '{}' '+'
 
 # Tailor (Swift) setup
-RUN curl -fsSL https://tailor.sh/install.sh | sed 's/read -r CONTINUE < \/dev\/tty/CONTINUE=y/' > install.sh && \
+RUN \
+  cd /tmp && \
+  curl -fsSL -o /tmp/install.orig \
+    https://raw.githubusercontent.com/sleekbyte/tailor/master/script/install.sh && \
+  sed 's/read -r CONTINUE < \/dev\/tty/CONTINUE=y/' install.orig > install.sh && \
   time /bin/bash install.sh && \
   find /tmp -mindepth 1 -prune -exec rm -rf '{}' '+'
 


### PR DESCRIPTION
Use GitHub host for tailor's install.sh, and
avoid pipe which masks failure.

Fixes https://github.com/coala/docker-coala-base/issues/179
Closes https://github.com/coala/docker-coala-base/issues/193