### PR TITLE
Remove unused Python 2 dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,11 @@ RUN \
     perl-X11-Protocol \
     php7-zlib \
     python-curses \
+    python2-packaging \
+    python2-Pygments \
+    python2-pyparsing \
     python-rpm-macros \
+    python2-setuptools \
     python-xml \
     R-core-doc \
     rsync \


### PR DESCRIPTION
Removes zypper packages:

- python2-packaging
- python2-Pygments
- python2-pyparsing
- python2-setuptools

Related to https://github.com/coala/docker-coala-base/issues/83
Related to https://github.com/coala/docker-coala-base/issues/55