### PR TITLE
Pin Python 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN \
     libopenssl-devel \
     # pcre needed by Julia runtime
     libpcre2-8-0 \
+    libpython3_6m1_0 \
     libxml2-devel \
     # libxml2-tools provides xmllint
     libxml2-tools \


### PR DESCRIPTION
Prevent unexpected upgrades to Python 3.7, and unintended
and unnoticed downgrades to lower versions of Python 3
if switching to openSUSE Leap.

Closes https://github.com/coala/docker-coala-base/issues/221
Related to https://github.com/coala/docker-coala-base/issues/144