### PR TITLE
Install pre-packaged luacheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,7 @@ RUN \
     linux-glibc-devel \
     liblua5_3-5 \
     lua53 \
-    lua53-devel \
-    lua53-luarocks \
+    luacheck \
     m4 \
     nltk-data-averaged_perceptron_tagger \
     nltk-data-punkt \
@@ -301,10 +300,6 @@ RUN time julia -e 'Pkg.add("Lint")' && \
     ~/.julia/v0.5/*/.git \
     ~/.julia/v0.5/*/test \
     ~/.julia/v0.5/*/docs && \
-  find /tmp -mindepth 1 -prune -exec rm -rf '{}' '+'
-
-# Lua commands
-RUN time luarocks install luacheck && \
   find /tmp -mindepth 1 -prune -exec rm -rf '{}' '+'
 
 # PMD setup

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ RUN \
       --plus-repo http://download.opensuse.org/repositories/home:illuusio/openSUSE_Tumbleweed/ \
       # astyle
       --plus-repo http://download.opensuse.org/repositories/devel:tools/openSUSE_Tumbleweed/ \
+      # stable packages built for coala
+      --plus-repo http://download.opensuse.org/repositories/home:jayvdb:coala/openSUSE_Tumbleweed/ \
       install --replacefiles \
     astyle \
     bzr \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ RUN \
       --plus-repo http://download.opensuse.org/repositories/home:illuusio/openSUSE_Tumbleweed/ \
       # astyle
       --plus-repo http://download.opensuse.org/repositories/devel:tools/openSUSE_Tumbleweed/ \
+      # Python 3 packages
+      --plus-repo http://download.opensuse.org/repositories/devel:languages:python3/openSUSE_Tumbleweed/ \
       # stable packages built for coala
       --plus-repo http://download.opensuse.org/repositories/home:jayvdb:coala/openSUSE_Tumbleweed/ \
       install --replacefiles \
@@ -78,6 +80,8 @@ RUN \
     lua53-devel \
     lua53-luarocks \
     m4 \
+    nltk-data-averaged_perceptron_tagger \
+    nltk-data-punkt \
     nodejs7 \
     npm7 \
     # patch is used by Ruby gem pg_query
@@ -99,6 +103,7 @@ RUN \
     python3-brotlipy \
     # Needed for proselint
     python3-dbm \
+    python3-nltk \
     python3-pip \
     python3-devel \
     R-base \
@@ -170,6 +175,9 @@ RUN \
     xorg-x11-fonts \
     xorg-x11-fonts-core \
     && \
+  # Disable nltk downloader
+  printf 'def download(*args): pass\ndownload_shell = download\n' \
+    > /usr/lib/python3.6/site-packages/nltk/downloader.py && \
   rm -rf \
     /usr/lib64/python2.7/doctest.py \
     /usr/lib64/python2.7/ensurepip/ \
@@ -224,8 +232,6 @@ RUN cd / && \
     -e /coala-quickstart \
     -r /coala/test-requirements.txt && \
   cd coala-bears && \
-  # NLTK data
-  time python3 -m nltk.downloader punkt maxent_treebank_pos_tagger averaged_perceptron_tagger && \
   # Remove Ruby directive from Gemfile as this image has 2.2.5
   sed -i '/^ruby/d' Gemfile && \
   # Ruby dependencies


### PR DESCRIPTION
Depends on https://github.com/coala/docker-coala-base/pull/149 , so that the log clearly shows the URLs of each package installed.

The logs show only one, luacheck, is being fetched from https://build.opensuse.org/project/show/home:jayvdb:coala

That repo will be used solely for stable packages, and each will be created in a separate repo.

For example, https://build.opensuse.org/package/show/home:jayvdb:coala/luacheck shows that it is a clone of https://build.opensuse.org/package/show/home:jayvdb:my_coala/luacheck .

It will also include packages created by others, such as @yukiisbored 's pg_query gem that is https://github.com/coala/docker-coala-base/pull/212 .

The [`my_coala`](https://build.opensuse.org/project/show/home:jayvdb:my_coala) repo is used only to contain packages that I have authored and are stable and ready for inclusion in the `coala` repo.

My personal development of new packages is being done in https://build.opensuse.org/project/show/home:jayvdb:test .  I then copy them to `my_coala` when they are ready for use.