### PR TITLE
Dockerfile: Install python3-brotlipy for HTTPolice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN \
       --plus-repo http://download.opensuse.org/repositories/science/openSUSE_Tumbleweed/ \
       # luarocks
       --plus-repo http://download.opensuse.org/repositories/devel:languages:lua/openSUSE_Factory/ \
+      # brotlipy
+      --plus-repo http://download.opensuse.org/repositories/devel:languages:python/openSUSE_Tumbleweed/ \
       # ruby 2.2
       --plus-repo http://download.opensuse.org/repositories/devel:languages:ruby/openSUSE_Tumbleweed/ \
       # flawfinder
@@ -90,6 +92,8 @@ RUN \
     # Used by bzr, mecurial, hgext, and flawfinder
     python \
     python3 \
+    # Needed for HTTpolice
+    python3-brotlipy \
     # Needed for proselint
     python3-dbm \
     python3-pip \


### PR DESCRIPTION
HTTPolice depends on brotlipy, which is a C extension that
needs libffi to compile.  Use openSUSE precomiled package instead.

Fixes https://github.com/coala/docker-coala-base/issues/237