### PR TITLE
Dockerfile: Use zypper --download-in-advance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN \
       --plus-repo http://download.opensuse.org/repositories/devel:languages:python3/openSUSE_Tumbleweed/ \
       # stable packages built for coala
       --plus-repo http://download.opensuse.org/repositories/home:jayvdb:coala/openSUSE_Tumbleweed/ \
-      install --replacefiles \
+      install --replacefiles --download-in-advance \
     astyle \
     bzr \
     cppcheck \


### PR DESCRIPTION
Install option --download-in-advance is required to enable
package File Conflicts to be reported before any installation
occurs.  The docker image provided zypp.conf leaves this
configuration unset, so it is enabled in this change.