### PR TITLE
Change maintainer to label maintainer in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM opensuse:tumbleweed
-MAINTAINER Fabian Neuschmidt fabian@neuschmidt.de
+LABEL maintainer="Fabian Neuschmidt fabian@neuschmidt.de"
 
 ARG branch=master
 RUN echo branch=$branch


### PR DESCRIPTION
Dockerfile: Change maintainer to label maintainer

This PR contains updated Dockerfile as per updated [doc](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated)
Changed `MAINTAINER` to `LABEL maintainer`

Closes #245 