### PR TITLE
Dockerfile: Updates deprecated MAINTAINER

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM opensuse:tumbleweed
-MAINTAINER Fabian Neuschmidt fabian@neuschmidt.de
+LABEL maintainer="Fabian Neuschmidt <fabian@neuschmidt.de>"
 
 ARG branch=master
 RUN echo branch=$branch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM opensuse:tumbleweed
-LABEL maintainer="Fabian Neuschmidt <fabian@neuschmidt.de>"
+LABEL MAINTAINER="Fabian Neuschmidt <fabian@neuschmidt.de>"
 
 ARG branch=master
 RUN echo branch=$branch


### PR DESCRIPTION
This changes `` MAINTAINER `` to ``LABEL maintainer``

Closes https://github.com/coala/docker-coala-base/issues/245